### PR TITLE
feat: add ClaudeCode tool_settings support for Leader/Evaluator/Judgment

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,6 +70,89 @@ config = LeaderConfig(model="groq:llama-3.3-70b-versatile", ...)
 config = LeaderConfig(model="claudecode:claude-sonnet-4-5", ...)
 ```
 
+### configure_claudecode_tool_settings
+
+```python
+def configure_claudecode_tool_settings(settings: ClaudeCodeToolSettings) -> None
+```
+
+Leader/Evaluator/JudgmentエージェントでClaudeCodeを使用する際のツール設定を登録します。
+
+`patch_core()` の前後どちらで呼び出しても有効です。設定は `patch_core()` によって作成されるClaudeCodeモデルに適用されます。
+
+**引数**
+
+| 名前 | 型 | 説明 |
+|------|-----|------|
+| `settings` | `ClaudeCodeToolSettings` | ClaudeCode固有のツール設定 |
+
+**ClaudeCodeToolSettings**
+
+| キー | 型 | 説明 |
+|------|-----|------|
+| `permission_mode` | `str` | パーミッションモード（`"bypassPermissions"` で確認スキップ） |
+| `working_directory` | `str` | 作業ディレクトリ |
+| `allowed_tools` | `list[str]` | 許可するツールのリスト |
+| `disallowed_tools` | `list[str]` | 禁止するツールのリスト |
+| `max_turns` | `int` | 最大ターン数 |
+
+**使用例**
+
+```python
+import mixseek_plus
+
+# ツール設定を登録
+mixseek_plus.configure_claudecode_tool_settings({
+    "permission_mode": "bypassPermissions",
+    "working_directory": "/workspace",
+})
+
+# パッチを適用（設定が反映される）
+mixseek_plus.patch_core()
+```
+
+### get_claudecode_tool_settings
+
+```python
+def get_claudecode_tool_settings() -> ClaudeCodeToolSettings | None
+```
+
+現在登録されているClaudeCodeツール設定を取得します。
+
+**戻り値**
+
+- 設定が登録されている場合: `ClaudeCodeToolSettings`
+- 設定が登録されていない場合: `None`
+
+**使用例**
+
+```python
+import mixseek_plus
+
+settings = mixseek_plus.get_claudecode_tool_settings()
+if settings:
+    print(settings.get("permission_mode"))
+```
+
+### clear_claudecode_tool_settings
+
+```python
+def clear_claudecode_tool_settings() -> None
+```
+
+登録されているClaudeCodeツール設定をクリアします。
+
+クリア後はデフォルトのClaudeCode動作に戻ります。
+
+**使用例**
+
+```python
+import mixseek_plus
+
+# 設定をクリア
+mixseek_plus.clear_claudecode_tool_settings()
+```
+
 ### check_groq_support
 
 ```python

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -197,6 +197,51 @@ import mixseek_plus
 mixseek_plus.patch_core()
 ```
 
+### Leader/Evaluator/JudgmentでのClaudeCode tool_settings設定
+
+Leader/Evaluator/JudgmentエージェントでClaudeCodeを使用する際に、`permission_mode`などのツール設定を適用するには、`configure_claudecode_tool_settings()`を使用します。
+
+```python
+import mixseek_plus
+
+# 1. ClaudeCode tool_settingsを設定（patch_coreの前後どちらでも可）
+mixseek_plus.configure_claudecode_tool_settings({
+    "permission_mode": "bypassPermissions",  # パーミッション確認をスキップ
+    "working_directory": "/workspace",        # 作業ディレクトリ
+})
+
+# 2. パッチを適用
+mixseek_plus.patch_core()
+
+# これでLeader/Evaluator/JudgmentがClaudeCodeの
+# Bash、Write等のツールを制限なく使用できる
+```
+
+**configure_claudecode_tool_settingsオプション:**
+
+| オプション | 型 | 説明 |
+|------------|-----|------|
+| `permission_mode` | `str` | パーミッションモード（`"bypassPermissions"` で確認スキップ） |
+| `working_directory` | `str` | 作業ディレクトリ |
+| `allowed_tools` | `list[str]` | 許可するツールのリスト |
+| `disallowed_tools` | `list[str]` | 禁止するツールのリスト |
+| `max_turns` | `int` | 最大ターン数 |
+
+**設定のクリア:**
+
+```python
+# 設定をクリアして、デフォルト動作に戻す
+mixseek_plus.clear_claudecode_tool_settings()
+```
+
+**現在の設定を取得:**
+
+```python
+# 現在の設定を確認
+settings = mixseek_plus.get_claudecode_tool_settings()
+print(settings)  # {"permission_mode": "bypassPermissions", ...}
+```
+
 ### TOML設定例（Groq）
 
 ```toml

--- a/src/mixseek_plus/__init__.py
+++ b/src/mixseek_plus/__init__.py
@@ -7,7 +7,14 @@ from mixseek_plus.agents import (
     register_claudecode_agents,
     register_groq_agents,
 )
-from mixseek_plus.core_patch import GroqNotPatchedError, check_groq_support, patch_core
+from mixseek_plus.core_patch import (
+    GroqNotPatchedError,
+    check_groq_support,
+    clear_claudecode_tool_settings,
+    configure_claudecode_tool_settings,
+    get_claudecode_tool_settings,
+    patch_core,
+)
 from mixseek_plus.errors import ClaudeCodeNotPatchedError, ModelCreationError
 from mixseek_plus.model_factory import create_model
 from mixseek_plus.providers.claudecode import create_claudecode_model
@@ -23,6 +30,9 @@ __all__ = [
     "register_groq_agents",
     "register_claudecode_agents",
     "patch_core",
+    "configure_claudecode_tool_settings",
+    "get_claudecode_tool_settings",
+    "clear_claudecode_tool_settings",
     "GroqNotPatchedError",
     "check_groq_support",
 ]

--- a/tests/unit/test_patch_core.py
+++ b/tests/unit/test_patch_core.py
@@ -6,7 +6,10 @@ Tests cover:
 - GR-062: Idempotency of patch_core()
 - GR-063: Unpatched usage detection and error message
 - CC-050, CC-051, CC-052: ClaudeCode support via patch_core()
+- CC-060, CC-061, CC-062: ClaudeCode tool_settings support for Leader/Evaluator/Judgment
 """
+
+from unittest.mock import patch
 
 import pytest
 from claudecode_model import ClaudeCodeModel
@@ -193,3 +196,149 @@ class TestUnpatchedErrorHandling:
         # because it's been patched at module level
         # Instead, we verify the is_patched state
         assert core_patch.is_patched() is False
+
+
+class TestClaudeCodeToolSettingsSupport:
+    """Tests for ClaudeCode tool_settings support in patch_core() (CC-060, CC-061, CC-062).
+
+    These tests verify that Leader/Evaluator/Judgment agents can use
+    ClaudeCode-specific tool_settings like permission_mode through patch_core().
+    """
+
+    def test_configure_claudecode_tool_settings_exists(self) -> None:
+        """CC-060: configure_claudecode_tool_settings function should exist."""
+        from mixseek_plus.core_patch import configure_claudecode_tool_settings
+
+        assert callable(configure_claudecode_tool_settings)
+
+    def test_configure_claudecode_tool_settings_registers_settings(self) -> None:
+        """CC-060: configure_claudecode_tool_settings should register settings."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            configure_claudecode_tool_settings,
+            get_claudecode_tool_settings,
+        )
+
+        # Clear any existing settings
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+
+        settings: dict[str, object] = {"permission_mode": "bypassPermissions"}
+        configure_claudecode_tool_settings(settings)  # type: ignore[arg-type]
+
+        result = get_claudecode_tool_settings()
+        assert result is not None
+        assert result.get("permission_mode") == "bypassPermissions"
+
+    def test_get_claudecode_tool_settings_returns_none_when_not_configured(
+        self,
+    ) -> None:
+        """get_claudecode_tool_settings returns None when not configured."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import get_claudecode_tool_settings
+
+        # Clear any existing settings
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+
+        result = get_claudecode_tool_settings()
+        assert result is None
+
+    def test_patched_create_model_uses_tool_settings(self) -> None:
+        """CC-061: After patch, claudecode: should use configured tool_settings."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            configure_claudecode_tool_settings,
+            patch_core,
+        )
+
+        # Reset patch state
+        core_patch._PATCH_APPLIED = False
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+
+        # Configure tool_settings before patching
+        configure_claudecode_tool_settings(
+            {
+                "permission_mode": "bypassPermissions",
+                "working_directory": "/test/dir",
+            }
+        )
+
+        # Apply patch
+        patch_core()
+
+        # Import after patching
+        from mixseek.core.auth import create_authenticated_model
+
+        # Mock ClaudeCodeModel to capture initialization args
+        with patch("mixseek_plus.providers.claudecode.ClaudeCodeModel") as mock_model:
+            mock_model.return_value = ClaudeCodeModel(model_name="claude-sonnet-4-5")
+            create_authenticated_model("claudecode:claude-sonnet-4-5")
+
+            # Verify tool_settings were passed
+            mock_model.assert_called_once()
+            call_kwargs = mock_model.call_args.kwargs
+            assert call_kwargs.get("permission_mode") == "bypassPermissions"
+            assert call_kwargs.get("working_directory") == "/test/dir"
+
+    def test_patched_create_model_works_without_tool_settings(self) -> None:
+        """CC-062: After patch, claudecode: works without tool_settings configured."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import patch_core
+
+        # Reset patch state and clear tool_settings
+        core_patch._PATCH_APPLIED = False
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+
+        # Apply patch without configuring tool_settings
+        patch_core()
+
+        from mixseek.core.auth import create_authenticated_model
+
+        # Should work without tool_settings
+        model = create_authenticated_model("claudecode:claude-sonnet-4-5")
+        assert isinstance(model, ClaudeCodeModel)
+
+    def test_configure_claudecode_tool_settings_with_all_options(self) -> None:
+        """configure_claudecode_tool_settings supports all ClaudeCode options."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            configure_claudecode_tool_settings,
+            get_claudecode_tool_settings,
+        )
+
+        # Clear any existing settings
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+
+        settings: dict[str, object] = {
+            "allowed_tools": ["Read", "Write"],
+            "disallowed_tools": ["Bash"],
+            "permission_mode": "bypassPermissions",
+            "working_directory": "/workspace",
+            "max_turns": 10,
+        }
+        configure_claudecode_tool_settings(settings)  # type: ignore[arg-type]
+
+        result = get_claudecode_tool_settings()
+        assert result is not None
+        assert result.get("allowed_tools") == ["Read", "Write"]
+        assert result.get("disallowed_tools") == ["Bash"]
+        assert result.get("permission_mode") == "bypassPermissions"
+        assert result.get("working_directory") == "/workspace"
+        assert result.get("max_turns") == 10
+
+    def test_clear_claudecode_tool_settings(self) -> None:
+        """clear_claudecode_tool_settings should clear registered settings."""
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            clear_claudecode_tool_settings,
+            configure_claudecode_tool_settings,
+            get_claudecode_tool_settings,
+        )
+
+        # Configure settings
+        core_patch._CLAUDECODE_TOOL_SETTINGS = None
+        configure_claudecode_tool_settings({"permission_mode": "bypassPermissions"})
+        assert get_claudecode_tool_settings() is not None
+
+        # Clear settings
+        clear_claudecode_tool_settings()
+        assert get_claudecode_tool_settings() is None


### PR DESCRIPTION
## Summary
- Add `configure_claudecode_tool_settings()` API to register ClaudeCode-specific settings (permission_mode, working_directory, allowed_tools, etc.)
- Add `get_claudecode_tool_settings()` and `clear_claudecode_tool_settings()` for settings management
- Integrate tool_settings with `patch_core()` so Leader/Evaluator/Judgment agents can use ClaudeCode features

## Test plan
- [ ] Run `uv run pytest tests/unit/test_patch_core.py` to verify new tool_settings tests pass
- [ ] Run `uv run ruff check .` and `uv run mypy .` for code quality
- [ ] Verify API reference documentation is accurate
- [ ] Test `configure_claudecode_tool_settings()` with actual ClaudeCode usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)