### PR TITLE
feat: patch create_leader_agent to call set_agent_toolsets for ClaudeCodeModel

### DIFF
--- a/tests/unit/test_patch_core.py
+++ b/tests/unit/test_patch_core.py
@@ -647,6 +647,8 @@ class TestLeaderAgentPatch:
         """_patch_leader_agent should call set_agent_toolsets for ClaudeCodeModel."""
         from unittest.mock import MagicMock, patch as mock_patch
 
+        from claudecode_model import ClaudeCodeModel
+
         from mixseek_plus import core_patch
         from mixseek_plus.core_patch import (
             _patch_leader_agent,
@@ -656,39 +658,243 @@ class TestLeaderAgentPatch:
         # Reset patch state
         core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
 
-        # Apply patch
-        _patch_leader_agent()
+        # Create mock tools
+        mock_tool1 = MagicMock(name="tool1")
+        mock_tool2 = MagicMock(name="tool2")
+        mock_tools = [mock_tool1, mock_tool2]
 
-        # Create mock ClaudeCodeModel with set_agent_toolsets
-        mock_claudecode_model = MagicMock()
+        # Create mock ClaudeCodeModel - must be actual instance for isinstance check
+        mock_claudecode_model = MagicMock(spec=ClaudeCodeModel)
         mock_claudecode_model.set_agent_toolsets = MagicMock()
 
         # Create mock leader agent with mock model
         mock_leader_agent = MagicMock()
         mock_leader_agent.model = mock_claudecode_model
-        mock_leader_agent._function_toolset.tools.values.return_value = [
-            MagicMock(name="tool1"),
-            MagicMock(name="tool2"),
-        ]
+        mock_leader_agent._function_toolset = MagicMock()
+        mock_leader_agent._function_toolset.tools = {
+            "tool1": mock_tool1,
+            "tool2": mock_tool2,
+        }
 
-        # Get the patched function
+        # Create mock team_config
+        mock_team_config = MagicMock()
+        mock_team_config.team_id = "test-team"
 
-        # Mock the original function to return our mock agent
-        with mock_patch.object(
-            core_patch,
-            "_ORIGINAL_CREATE_LEADER_AGENT",
-            return_value=mock_leader_agent,
+        # Mock original function to return our mock agent
+        mock_original_func = MagicMock(return_value=mock_leader_agent)
+
+        # Apply patch
+        with mock_patch(
+            "mixseek.agents.leader.agent.create_leader_agent",
+            mock_original_func,
         ):
-            # Reapply patch with our mocked original
-            reset_leader_agent_patch()
-            core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
             _patch_leader_agent()
 
-            # The patched function should call set_agent_toolsets
-            # Since we can't easily test the full flow, verify the patch was applied
-            assert core_patch._ORIGINAL_CREATE_LEADER_AGENT is not None
+            # Get patched function from module
+            import mixseek.agents.leader.agent as leader_module
+
+            patched_func = leader_module.create_leader_agent
+
+            # Call patched function
+            result = patched_func(mock_team_config, {})
+
+            # Verify set_agent_toolsets was called with the tools
+            mock_claudecode_model.set_agent_toolsets.assert_called_once_with(mock_tools)
+            assert result == mock_leader_agent
 
         # Cleanup
+        reset_leader_agent_patch()
+
+    def test_patch_leader_agent_does_not_call_set_agent_toolsets_for_non_claudecode(
+        self,
+    ) -> None:
+        """_patch_leader_agent should NOT call set_agent_toolsets for non-ClaudeCodeModel."""
+        from unittest.mock import MagicMock, patch as mock_patch
+
+        from pydantic_ai.models.groq import GroqModel
+
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            _patch_leader_agent,
+            reset_leader_agent_patch,
+        )
+
+        # Reset patch state
+        core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
+
+        # Create mock non-ClaudeCode model (Groq)
+        mock_groq_model = MagicMock(spec=GroqModel)
+        mock_groq_model.set_agent_toolsets = MagicMock()
+
+        # Create mock leader agent
+        mock_leader_agent = MagicMock()
+        mock_leader_agent.model = mock_groq_model
+
+        mock_team_config = MagicMock()
+        mock_team_config.team_id = "test-team"
+
+        mock_original_func = MagicMock(return_value=mock_leader_agent)
+
+        with mock_patch(
+            "mixseek.agents.leader.agent.create_leader_agent",
+            mock_original_func,
+        ):
+            _patch_leader_agent()
+
+            import mixseek.agents.leader.agent as leader_module
+
+            patched_func = leader_module.create_leader_agent
+
+            result = patched_func(mock_team_config, {})
+
+            # Verify set_agent_toolsets was NOT called
+            mock_groq_model.set_agent_toolsets.assert_not_called()
+            assert result == mock_leader_agent
+
+        reset_leader_agent_patch()
+
+    def test_patch_leader_agent_does_not_call_set_agent_toolsets_with_empty_tools(
+        self,
+    ) -> None:
+        """_patch_leader_agent should NOT call set_agent_toolsets when tools is empty."""
+        from unittest.mock import MagicMock, patch as mock_patch
+
+        from claudecode_model import ClaudeCodeModel
+
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            _patch_leader_agent,
+            reset_leader_agent_patch,
+        )
+
+        core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
+
+        mock_claudecode_model = MagicMock(spec=ClaudeCodeModel)
+        mock_claudecode_model.set_agent_toolsets = MagicMock()
+
+        mock_leader_agent = MagicMock()
+        mock_leader_agent.model = mock_claudecode_model
+        mock_leader_agent._function_toolset = MagicMock()
+        mock_leader_agent._function_toolset.tools = {}  # Empty tools
+
+        mock_team_config = MagicMock()
+        mock_team_config.team_id = "test-team"
+
+        mock_original_func = MagicMock(return_value=mock_leader_agent)
+
+        with mock_patch(
+            "mixseek.agents.leader.agent.create_leader_agent",
+            mock_original_func,
+        ):
+            _patch_leader_agent()
+
+            import mixseek.agents.leader.agent as leader_module
+
+            patched_func = leader_module.create_leader_agent
+
+            result = patched_func(mock_team_config, {})
+
+            # Verify set_agent_toolsets was NOT called when tools empty
+            mock_claudecode_model.set_agent_toolsets.assert_not_called()
+            assert result == mock_leader_agent
+
+        reset_leader_agent_patch()
+
+    def test_patch_leader_agent_handles_function_toolset_access_error(
+        self,
+    ) -> None:
+        """_patch_leader_agent should handle _function_toolset access errors gracefully."""
+        from unittest.mock import MagicMock, PropertyMock, patch as mock_patch
+
+        from claudecode_model import ClaudeCodeModel
+
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            _patch_leader_agent,
+            reset_leader_agent_patch,
+        )
+
+        core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
+
+        mock_claudecode_model = MagicMock(spec=ClaudeCodeModel)
+        mock_claudecode_model.set_agent_toolsets = MagicMock()
+
+        mock_leader_agent = MagicMock()
+        mock_leader_agent.model = mock_claudecode_model
+        # Make _function_toolset.tools raise AttributeError
+        type(mock_leader_agent)._function_toolset = PropertyMock(
+            side_effect=AttributeError("_function_toolset not found")
+        )
+
+        mock_team_config = MagicMock()
+        mock_team_config.team_id = "test-team"
+
+        mock_original_func = MagicMock(return_value=mock_leader_agent)
+
+        with mock_patch(
+            "mixseek.agents.leader.agent.create_leader_agent",
+            mock_original_func,
+        ):
+            _patch_leader_agent()
+
+            import mixseek.agents.leader.agent as leader_module
+
+            patched_func = leader_module.create_leader_agent
+
+            # Should not raise, returns leader_agent
+            result = patched_func(mock_team_config, {})
+
+            # Verify set_agent_toolsets was NOT called due to error
+            mock_claudecode_model.set_agent_toolsets.assert_not_called()
+            assert result == mock_leader_agent
+
+        reset_leader_agent_patch()
+
+    def test_patch_leader_agent_handles_none_function_toolset(
+        self,
+    ) -> None:
+        """_patch_leader_agent should handle None _function_toolset gracefully."""
+        from unittest.mock import MagicMock, patch as mock_patch
+
+        from claudecode_model import ClaudeCodeModel
+
+        from mixseek_plus import core_patch
+        from mixseek_plus.core_patch import (
+            _patch_leader_agent,
+            reset_leader_agent_patch,
+        )
+
+        core_patch._ORIGINAL_CREATE_LEADER_AGENT = None
+
+        mock_claudecode_model = MagicMock(spec=ClaudeCodeModel)
+        mock_claudecode_model.set_agent_toolsets = MagicMock()
+
+        # Create mock without _function_toolset attribute
+        mock_leader_agent = MagicMock(spec=["model"])  # No _function_toolset
+        mock_leader_agent.model = mock_claudecode_model
+
+        mock_team_config = MagicMock()
+        mock_team_config.team_id = "test-team"
+
+        mock_original_func = MagicMock(return_value=mock_leader_agent)
+
+        with mock_patch(
+            "mixseek.agents.leader.agent.create_leader_agent",
+            mock_original_func,
+        ):
+            _patch_leader_agent()
+
+            import mixseek.agents.leader.agent as leader_module
+
+            patched_func = leader_module.create_leader_agent
+
+            # Should not raise, returns leader_agent
+            result = patched_func(mock_team_config, {})
+
+            # Verify set_agent_toolsets was NOT called
+            mock_claudecode_model.set_agent_toolsets.assert_not_called()
+            assert result == mock_leader_agent
+
         reset_leader_agent_patch()
 
     def test_patch_leader_agent_skips_non_claudecode(self) -> None:


### PR DESCRIPTION
## Summary

- ClaudeCodeModel使用時にLeader agentの`_function_toolset`からToolオブジェクトを取得し、`set_agent_toolsets()`を呼び出すパッチを実装
- `_patch_leader_agent()`関数を追加し、`patch_core()`から呼び出す
- テスト用の`reset_leader_agent_patch()`関数を追加

## Test plan

- [ ] `uv run ruff check --fix . && uv run ruff format . && uv run mypy .` - 品質チェック通過
- [ ] `uv run pytest tests/unit/test_patch_core.py -v` - 30テスト全て通過
- [ ] `uv run pytest` - 全テスト通過
- [ ] 手動統合テスト: ClaudeCode workspaceで「Leader did not call any member tools」警告が表示されないことを確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)