### PR TITLE
docs: add Groq model list and GroqWebSearchAgent usage example

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -268,6 +268,10 @@ def __init__(self, config: MemberAgentConfig) -> None
 **使用例（Python）**
 
 ```python
+# 必要な環境変数:
+# - GROQ_API_KEY: Groq APIキー
+# - TAVILY_API_KEY: Tavily APIキー（Web検索用）
+
 import asyncio
 from mixseek.models.member_agent import MemberAgentConfig
 from mixseek_plus.agents.groq_web_search_agent import GroqWebSearchAgent

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,6 +49,10 @@ model = create_model("anthropic:claude-sonnet-4-5-20250929")
 | `groq:meta-llama/llama-4-scout-17b-16e-instruct` | Preview | |
 | `groq:qwen/qwen3-32b` | Preview | |
 
+> **Note**: モデルリストは変更される可能性があります。最新情報は[Groq公式ドキュメント](https://console.groq.com/docs/models)を参照してください。
+>
+> *最終更新: 2026年1月*
+
 ## Memberエージェント
 
 mixseek-plusは、Groq Memberエージェント（2種類）とClaudeCode Memberエージェント（1種類）を提供します。


### PR DESCRIPTION
## Summary
- Add available Groq models table with Production/Preview classification to user-guide.md
- Add Python usage example for GroqWebSearchAgent with MemberAgentConfig to api-reference.md

## Test plan
- [ ] Verify markdown renders correctly in documentation
- [ ] Confirm code example is syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)