### PR TITLE
fix(claudecode): handle session timeout for CLI tool calls

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -225,6 +225,7 @@ allowed_tools = ["Read", "Glob", "Grep"]
 | `permission_mode` | `str` | パーミッションモード（`"bypassPermissions"` で確認スキップ） |
 | `working_directory` | `str` | 作業ディレクトリ |
 | `max_turns` | `int` | 最大ターン数 |
+| `timeout_seconds` | `int` | CLIセッションのタイムアウト秒数（デフォルト: 3600） |
 
 **設定例:**
 

--- a/specs/008-claudecode-provider/data-model.md
+++ b/specs/008-claudecode-provider/data-model.md
@@ -89,6 +89,7 @@ class ClaudeCodeToolSettings(TypedDict, total=False):
     permission_mode: str
     working_directory: str
     max_turns: int
+    timeout_seconds: int
 ```
 
 **TOML表現**:
@@ -99,6 +100,7 @@ disallowed_tools = ["Write", "Edit"]
 permission_mode = "bypassPermissions"
 working_directory = "/tmp"
 max_turns = 5
+timeout_seconds = 3600
 ```
 
 ### 5. ClaudeCodeNotPatchedError
@@ -200,6 +202,7 @@ stateDiagram-v2
 | `permission_mode` | 文字列、特定値は検証しない |
 | `working_directory` | 文字列、パス存在チェックなし |
 | `max_turns` | 正整数 |
+| `timeout_seconds` | 正整数、CLIセッションタイムアウト（デフォルト: 3600） |
 
 ## Error Types
 


### PR DESCRIPTION
## Summary

- Add support for configurable ClaudeCode CLI session timeout with a default of 3600 seconds
- Fix issue where HTTP API timeouts (LeaderAgentConfig.timeout_seconds) were incorrectly applied to CLI sessions that may include tool calls and member agent execution
- Implement timeout stripping mechanism to use CLI-specific timeouts instead

## Implementation Details

- Added `CLAUDECODE_SESSION_TIMEOUT_SECONDS` constant (3600 seconds)
- Implemented `_strip_timeout_from_settings()` method to remove HTTP API timeouts from model_settings
- Added `timeout_seconds` parameter to `ClaudeCodeToolSettings` TypedDict
- Updated `create_claudecode_model()` to accept and apply timeout configuration
- Updated documentation in user guide and data model spec

Closes #52

## Test plan

- [x] Quality checks passed (ruff check, ruff format, mypy)
- [ ] Manual testing of ClaudeCode provider with timeout configuration
- [ ] Verify timeout is applied correctly in team configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)