### PR TITLE
Prevent delegate_only preset from leaking to member agents

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -78,7 +78,7 @@ def configure_claudecode_tool_settings(settings: ClaudeCodeToolSettings) -> None
 
 Leader/Evaluator/JudgmentエージェントでClaudeCodeを使用する際のツール設定を登録します。
 
-`patch_core()` の前後どちらで呼び出しても有効です。設定は `patch_core()` によって作成されるClaudeCodeモデルに適用されます。
+`patch_core()` の前後どちらで呼び出しても有効です。設定はLeader/Evaluator/Judgmentモジュール経由で作成されるClaudeCodeモデルにのみ適用されます。Memberエージェントには適用されません（Memberは自身のTOML設定 `[agent.tool_settings.claudecode]` を使用します）。
 
 **引数**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -478,6 +478,8 @@ mixseek_plus.patch_core()
 
 Leader/Evaluator/JudgmentエージェントでClaudeCodeを使用する際に、`permission_mode`などのツール設定を適用するには、`configure_claudecode_tool_settings()`を使用します。
 
+この設定はLeader/Evaluator/Judgmentにのみ適用され、Memberエージェントには影響しません。Memberエージェントは自身のTOML設定（`[agent.tool_settings.claudecode]`）で個別に制御します。
+
 ```python
 import mixseek_plus
 
@@ -492,6 +494,7 @@ mixseek_plus.patch_core()
 
 # これでLeader/Evaluator/JudgmentがClaudeCodeの
 # Bash、Write等のツールを制限なく使用できる
+# Memberエージェントは影響を受けない
 ```
 
 **configure_claudecode_tool_settingsオプション:**

--- a/uv.lock
+++ b/uv.lock
@@ -423,11 +423,12 @@ dependencies = [
 
 [[package]]
 name = "claudecode-model"
-version = "0.0.26"
-source = { git = "https://github.com/drillan/claudecode-model.git#a3e7f7d8b7c8fb49342192b885de6e017e844de8" }
+version = "0.0.27"
+source = { git = "https://github.com/drillan/claudecode-model.git#af5a1d5a90f9346ad28c6c311fef86aa858d25b6" }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "dacite" },
+    { name = "mcp" },
     { name = "pydantic-ai" },
 ]
 


### PR DESCRIPTION
## Summary
- Separated create_authenticated_model into two paths: base version (no tool_settings) for general callers and leader-aware version (with tool_settings) for Leader/Evaluator/Judgment modules
- Prevents delegate_only preset from inadvertently constraining member agent capabilities
- Enhanced error handling with logging for module import failures
- Added comprehensive test suite (TestToolSettingsIsolation) with 6 test cases

Closes #56

## Test plan
- TestToolSettingsIsolation: Verifies auth module doesn't apply leader settings, while Leader/Evaluator/Judgment modules do
- Test cases cover: auth module isolation, leader/evaluator/judgment module application, groq compatibility, and graceful error handling
- All tests pass, demonstrating correct tool_settings isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)