### PR TITLE
fix(claudecode): increase default session timeout from 3600 to 7200 seconds

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -225,7 +225,7 @@ allowed_tools = ["Read", "Glob", "Grep"]
 | `permission_mode` | `str` | パーミッションモード（デフォルト: `"bypassPermissions"`、確認スキップ） |
 | `working_directory` | `str` | 作業ディレクトリ |
 | `max_turns` | `int` | 最大ターン数 |
-| `timeout_seconds` | `int` | CLIセッションのタイムアウト秒数（デフォルト: 3600） |
+| `timeout_seconds` | `int` | CLIセッションのタイムアウト秒数（デフォルト: 7200） |
 
 **設定例:**
 

--- a/specs/008-claudecode-provider/data-model.md
+++ b/specs/008-claudecode-provider/data-model.md
@@ -202,7 +202,7 @@ stateDiagram-v2
 | `permission_mode` | 文字列、特定値は検証しない |
 | `working_directory` | 文字列、パス存在チェックなし |
 | `max_turns` | 正整数 |
-| `timeout_seconds` | 正整数、CLIセッションタイムアウト（デフォルト: 3600） |
+| `timeout_seconds` | 正整数、CLIセッションタイムアウト（デフォルト: 7200） |
 
 ## Error Types
 

--- a/specs/008-claudecode-provider/data-model.md
+++ b/specs/008-claudecode-provider/data-model.md
@@ -100,7 +100,7 @@ disallowed_tools = ["Write", "Edit"]
 permission_mode = "bypassPermissions"
 working_directory = "/tmp"
 max_turns = 5
-timeout_seconds = 3600
+timeout_seconds = 7200
 ```
 
 ### 5. ClaudeCodeNotPatchedError

--- a/src/mixseek_plus/providers/claudecode.py
+++ b/src/mixseek_plus/providers/claudecode.py
@@ -14,7 +14,7 @@ from pydantic_ai.usage import RequestUsage
 # ツール呼び出しやメンバーエージェント実行を含む全体の時間が必要なため、
 # より長いタイムアウトを設定する。
 # オーケストレータのtimeout_per_team_secondsが上位のセーフティネットとして機能する。
-CLAUDECODE_SESSION_TIMEOUT_SECONDS = 3600
+CLAUDECODE_SESSION_TIMEOUT_SECONDS = 7200
 
 
 class FixedTokenClaudeCodeModel(ClaudeCodeModel):

--- a/tests/unit/test_claudecode_provider.py
+++ b/tests/unit/test_claudecode_provider.py
@@ -338,9 +338,9 @@ class TestClaudeCodeSessionTimeout:
     コンストラクタで設定したより長いタイムアウトを使用する。
     """
 
-    def test_default_session_timeout_is_3600(self) -> None:
-        """デフォルトのセッションタイムアウトが3600秒であることを確認."""
-        assert CLAUDECODE_SESSION_TIMEOUT_SECONDS == 3600
+    def test_default_session_timeout_is_7200(self) -> None:
+        """デフォルトのセッションタイムアウトが7200秒であることを確認."""
+        assert CLAUDECODE_SESSION_TIMEOUT_SECONDS == 7200
 
     def test_create_claudecode_model_uses_default_timeout(self) -> None:
         """create_claudecode_modelがデフォルトタイムアウトをコンストラクタに渡す."""

--- a/tests/unit/test_claudecode_provider.py
+++ b/tests/unit/test_claudecode_provider.py
@@ -350,12 +350,13 @@ class TestClaudeCodeSessionTimeout:
 
     def test_create_claudecode_model_with_custom_timeout(self) -> None:
         """tool_settings.timeout_secondsでカスタムタイムアウトを設定できる."""
-        tool_settings: ClaudeCodeToolSettings = {"timeout_seconds": 7200}
+        custom_timeout = 9999
+        tool_settings: ClaudeCodeToolSettings = {"timeout_seconds": custom_timeout}
         model = create_claudecode_model(
             "claude-sonnet-4-5", tool_settings=tool_settings
         )
         assert isinstance(model, FixedTokenClaudeCodeModel)
-        assert model._timeout == 7200
+        assert model._timeout == custom_timeout
 
     def test_create_claudecode_model_with_tool_settings_no_timeout(self) -> None:
         """tool_settingsにtimeout_secondsがない場合はデフォルトを使用."""
@@ -374,7 +375,8 @@ class TestClaudeCodeSessionTimeout:
         ClaudeCode CLIセッションではコンストラクタのタイムアウトを使用すべき。
         """
         model = FixedTokenClaudeCodeModel(
-            model_name="claude-sonnet-4-5", timeout=3600.0
+            model_name="claude-sonnet-4-5",
+            timeout=float(CLAUDECODE_SESSION_TIMEOUT_SECONDS),
         )
 
         model_settings: ModelSettings = {"timeout": 300}
@@ -399,7 +401,8 @@ class TestClaudeCodeSessionTimeout:
     async def test_request_preserves_other_model_settings(self) -> None:
         """request()がtimeout以外のmodel_settingsを保持することを確認."""
         model = FixedTokenClaudeCodeModel(
-            model_name="claude-sonnet-4-5", timeout=3600.0
+            model_name="claude-sonnet-4-5",
+            timeout=float(CLAUDECODE_SESSION_TIMEOUT_SECONDS),
         )
 
         model_settings: ModelSettings = {"timeout": 300, "temperature": 0.5}
@@ -425,7 +428,8 @@ class TestClaudeCodeSessionTimeout:
     async def test_request_handles_none_model_settings(self) -> None:
         """model_settingsがNoneの場合も正常に動作することを確認."""
         model = FixedTokenClaudeCodeModel(
-            model_name="claude-sonnet-4-5", timeout=3600.0
+            model_name="claude-sonnet-4-5",
+            timeout=float(CLAUDECODE_SESSION_TIMEOUT_SECONDS),
         )
 
         original_response = ModelResponse(
@@ -448,7 +452,8 @@ class TestClaudeCodeSessionTimeout:
     async def test_request_handles_settings_without_timeout(self) -> None:
         """model_settingsにtimeoutがない場合はそのまま渡すことを確認."""
         model = FixedTokenClaudeCodeModel(
-            model_name="claude-sonnet-4-5", timeout=3600.0
+            model_name="claude-sonnet-4-5",
+            timeout=float(CLAUDECODE_SESSION_TIMEOUT_SECONDS),
         )
 
         model_settings: ModelSettings = {"temperature": 0.0}


### PR DESCRIPTION
## Summary

- Increased ClaudeCode CLI session timeout from 3600 seconds (1 hour) to 7200 seconds (2 hours)
- Aligns with longer-running agent workflows involving nested tool calls and member agent execution
- Updated configuration documentation and test assertions to reflect new default

Closes #62

## Test plan

- [x] Updated test assertions verify default timeout is 7200 seconds
- [x] Documentation (user-guide.md, data-model.md) reflects new default
- [x] Code comments preserved explaining timeout behavior and orchestrator safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)